### PR TITLE
update page model/serializer for rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.4]
+### Changed
+- normalize page row data on fetch
+- page model exposes rows, not cards
+
 ## [0.0.2]
 ### Changed
 - added author and description to package.json

--- a/addon/models/page.js
+++ b/addon/models/page.js
@@ -15,5 +15,5 @@
    ownerName: DS.attr('string'),
    updatedAt: DS.attr('date'),
    affiliation: DS.attr('string'),
-   cards: DS.attr() //array of card objects
+   rows: DS.attr() //array of row objects
  });

--- a/addon/serializers/page.js
+++ b/addon/serializers/page.js
@@ -33,6 +33,23 @@ export default DS.JSONAPISerializer.extend({
         }
       }
 
+      // normalize row data
+      // add cards under rows
+      if (!page.attributes.rows || page.attributes.rows.length === 0) {
+        page.attributes.rows = [{
+          cards: page.attributes.cards,
+          style: {}
+        }];
+      }
+      // no longer using top level cards, should be in first row
+      delete page.attributes.cards;
+      // make sure each row has a style
+      page.attributes.rows.forEach(row => {
+        if (!row.style) {
+          row.style = {};
+        }
+      });
+
       return page;
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-arcgis-opendata",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Ember Data model and adapters for the ArcGIS OpenData API",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
- normalize page row data on fetch
- page model exposes rows, not cards
